### PR TITLE
Update Timer.hx

### DIFF
--- a/src/thx/Timer.hx
+++ b/src/thx/Timer.hx
@@ -286,7 +286,7 @@ Note that the initial value might change from platform to platform so only delta
   static function __init__() untyped {
     // Polyfills
     // SCOPE
-    var scope : Dynamic = __js__('("undefined" !== typeof window && window) || ("undefined" !== typeof global && global) || this');
+    var scope : Dynamic = __js__('("undefined" !== typeof window && window) || ("undefined" !== typeof global && global) || Function("return this")()');
 
     // setImmediate
     if(!scope.setImmediate)


### PR DESCRIPTION
Function("return this")() actually returns the global object in strict mode, "this" alone doesn't.
See http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript for more.
